### PR TITLE
Add RTX_PYENV_REPO env

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,7 +16,7 @@ ensure_python_build_installed() {
 
 download_python_build() {
   echo "Downloading python-build..." >&2
-  local pyenv_url="https://github.com/pyenv/pyenv.git"
+  local pyenv_url="${RTX_PYENV_REPOSITORY:-https://github.com/pyenv/pyenv.git}"
   git clone $pyenv_url "$(pyenv_path)"
 }
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,7 +16,7 @@ ensure_python_build_installed() {
 
 download_python_build() {
   echo "Downloading python-build..." >&2
-  local pyenv_url="${RTX_PYENV_REPOSITORY:-https://github.com/pyenv/pyenv.git}"
+  local pyenv_url="${RTX_PYENV_REPO:-https://github.com/pyenv/pyenv.git}"
   git clone $pyenv_url "$(pyenv_path)"
 }
 


### PR DESCRIPTION
`rtx-python` use pyenv to download and build python, when you run `rtx ls-remote python` or commands like that. you need `pyenv` installed in plugins/python directory.

in China, without vpn, the connection to GitHub is unstable, with this `RTX_PYENV_REPO` env, we can improve rtx experience drastically.

eg.

```
# for pyenv in rtx-python plugin
export RTX_PYENV_REPO="https://ghproxy.com/https://github.com/pyenv/pyenv.git"

# for rtx install python@xxxx (from pyenv)
export PYTHON_BUILD_MIRROR_URL_SKIP_CHECKSUM=false
export PYTHON_BUILD_MIRROR_URL=https://repo.huaweicloud.com/python/
```